### PR TITLE
fix: Corrigindo rota de cadastrarNovaEscuta

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ catch (\Exception $exception)
 
 ## Paginando recursos
 
-A maioria dos recursos do SDK possuem paginação, que pode ser acessada atravez da classe 
+Para obter todos os dados de um recurso pode ser utilizado o sistema de paginação. A maioria dos recursos do SDK possuem paginação, que pode ser acessada atravez da classe 
 [**Paginator**](./docs/models/api/Paginator.md). A utilização da paginação de um recurso é bem simples:
-
+###### Exemplo para obter as copias processuais e manipular o resultado com o recurso de paginação
 ```php
 <?php
 
@@ -99,8 +99,10 @@ try
 {
     $intimaai = new Intimaai('api_token');
 
+    // Acessando todas as copias processuas do usuário
     $paginacao = $intimaai->copiasProcessuais->paginar();
 
+    // Manipulando o objeto Paginator retornado
     $paginacao->obterPagina(1);
     $paginacao->proximaPagina();
     $paginacao->paginaAnterior();

--- a/docs/models/auth/AtivarIntimacoesParaAutenticacao.md
+++ b/docs/models/auth/AtivarIntimacoesParaAutenticacao.md
@@ -4,7 +4,7 @@
 Nome | Tipo | Descrição | Notas
 ------------ | ------------- | ------------- | -------------
 **abas** | **string[]** | são as abas que deseja capturas as intimações (valores aceitos: PENDENTES_DE_CIENCIA, CIENCIA_DADA_PELO_DESTINATARIO_DENTRO_DO_PRAZO, CIENCIA_DADA_PELO_JUDICIARIO_DENTRO_DO_PRAZO e SEM_PRAZO) | [obrigatório] 
-**diasDasemana** | **int[]** | dias da semana em que deseja capturar as intimações (valores aceitos: 0, 1, 2, 3, 4, 5, 6) | [obrigatório] 
+**diasDasemana** | **int[]** | dias da semana em que deseja capturar as intimações (valores aceitos: 0, 1, 2, 3, 4, 5, 6. Correspondendo de domingo a sábado) | [obrigatório] 
 **horasDoDia** | **string[]** | horários do dia que deseja capturar as intimações (valores aceitos: das 06:00 até 00:00) | [obrigatório] 
 
 [[Voltar a lista da API]](../../../README.md#Documentação-para-os-Endpoints-da-API)    

--- a/docs/models/auth/AtualizarAutenticacao.md
+++ b/docs/models/auth/AtualizarAutenticacao.md
@@ -1,15 +1,11 @@
-# NovaAutenticacao
+# AtualizarAutenticacao
 
 ## Propriedades
 Nome | Tipo | Descrição | Notas
 ------------ | ------------- | ------------- | -------------
-**tribunalId** | **int** | é o id referente ao tribunal cadastrado em "Tribunais ativos" no Intima.ai | [obrigatório] 
-**certificadoId** | **int** | é o id do certificado cadastrado no Intima.ai | [opcional] 
-**login** | **string** | login do seu usuário | [opcional] 
-**senha** | **string** | senha do seu usuário | [opcional] 
-**oabNumero** | **string** | numero da OAB | [opcional] 
+**oabNumero** | **string** | numero da OAB | [obrigatório] 
 **oabLetra** | **string** | letra da OAB | [opcional] 
-**oabUf** | **string** | UF a qual pertence a sua OAB | [opcional] 
+**oabUf** | **string** | UF a qual pertence a sua OAB | [obrigatório] 
 
 [[Voltar a lista da API]](../../../README.md#Documentação-para-os-Endpoints-da-API)    
 [[Voltar para o README]](../../../README.md#Intima.ai---SDK-PHP)

--- a/docs/models/copy/CopiaProcessual.md
+++ b/docs/models/copy/CopiaProcessual.md
@@ -3,8 +3,8 @@
 ## Propriedades
 Nome | Tipo | Descrição | Notas
 ------------ | ------------- | ------------- | -------------
-**autenticacaoId** | **int** | é o id referente ao tribunal cadastrado em "Tribunais ativos" no Intima.ai | [obrigatório] 
 **numeroProcesso** | **string** | é o numero do processo no qual se deseja realizar a cópia | [obrigatório] 
+**autenticacaoId** | **int** | é o id referente ao tribunal cadastrado em "Tribunais ativos" no Intima.ai | [obrigatório] 
 
 [[Voltar a lista da API]](../../../README.md#Documentação-para-os-Endpoints-da-API)    
 [[Voltar para o README]](../../../README.md#Intima.ai---SDK-PHP)

--- a/docs/models/listener/AtualizarEscutaProcessual.md
+++ b/docs/models/listener/AtualizarEscutaProcessual.md
@@ -1,4 +1,4 @@
-    # AtualizarEscutaProcessual
+# AtualizarEscutaProcessual
 
 ## Propriedades
 Nome | Tipo | Descrição | Notas

--- a/docs/models/listener/EscutaProcessual.md
+++ b/docs/models/listener/EscutaProcessual.md
@@ -3,8 +3,8 @@
 ## Propriedades
 Nome | Tipo | Descrição | Notas
 ------------ | ------------- | ------------- | -------------
-**autenticacaoId** | **int** | é o id referente ao tribunal cadastrado em "Tribunais ativos" no Intima.ai | [obrigatório] 
 **numeroProcesso** | **string** | é o numero do processo no qual se deseja realizar a cópia | [obrigatório] 
+**autenticacaoId** | **int** | é o id referente ao tribunal cadastrado em "Tribunais ativos" no Intima.ai | [obrigatório] 
 **diasDeCaptura** | **int[]** | são os dias em que as consultas serão realizadas (valores aceitos: de 0 a 6 (sendo "0" domingo e "6" sábado)) | [obrigatório]
 **horariosDeCaptura** | **string[]** | são os horários do dia em que deseja realizar as escutas (valores aceitos: das 06:00 as 00:00) | [obrigatório] 
 

--- a/docs/models/process_course/AndamentoProcessual.md
+++ b/docs/models/process_course/AndamentoProcessual.md
@@ -3,8 +3,8 @@
 ## Propriedades
 Nome | Tipo | Descrição | Notas
 ------------ | ------------- | ------------- | -------------
-**autenticacaoId** | **int** | é o id referente ao tribunal cadastrado em "Tribunais ativos" no Intima.ai | [obrigatório] 
 **numeroProcesso** | **string** | é o numero do processo | [obrigatório] 
+**autenticacaoId** | **int** | é o id referente ao tribunal cadastrado em "Tribunais ativos" no Intima.ai | [obrigatório] 
 
 [[Voltar a lista da API]](../../../README.md#Documentação-para-os-Endpoints-da-API)    
 [[Voltar para o README]](../../../README.md#Intima.ai---SDK-PHP)

--- a/docs/models/process_info/InformacaoProcessual.md
+++ b/docs/models/process_info/InformacaoProcessual.md
@@ -3,8 +3,8 @@
 ## Propriedades
 Nome | Tipo | Descrição | Notas
 ------------ | ------------- | ------------- | -------------
-**autenticacaoId** | **int** | é o id referente ao tribunal cadastrado em "Tribunais ativos" no Intima.ai | [obrigatório] 
 **numeroProcesso** | **string** | é o numero do processo | [obrigatório] 
+**autenticacaoId** | **int** | é o id referente ao tribunal cadastrado em "Tribunais ativos" no Intima.ai | [obrigatório] 
 
 [[Voltar a lista da API]](../../../README.md#Documentação-para-os-Endpoints-da-API)    
 [[Voltar para o README]](../../../README.md#Intima.ai---SDK-PHP)

--- a/docs/models/protocol/PrimeiraEtapaParaProtocoloProcessualEsaj.md
+++ b/docs/models/protocol/PrimeiraEtapaParaProtocoloProcessualEsaj.md
@@ -3,8 +3,8 @@
 ## Propriedades
 Nome | Tipo | Descrição | Notas
 ------------ | ------------- | ------------- | -------------
-**autenticacaoId** | **int** | é o id referente ao tribunal cadastrado em "Tribunais ativos" no Intima.ai | [obrigatório] 
 **numeroProcesso** | **string** | é o numero do processo no qual se deseja realizar o protocolo | [obrigatório] 
+**autenticacaoId** | **int** | é o id referente ao tribunal cadastrado em "Tribunais ativos" no Intima.ai | [obrigatório] 
 
 [[Voltar a lista da API]](../../../README.md#Documentação-para-os-Endpoints-da-API)    
 [[Voltar para o README]](../../../README.md#Intima.ai---SDK-PHP)

--- a/docs/models/protocol/PrimeiraEtapaParaProtocoloProcessualTjrj.md
+++ b/docs/models/protocol/PrimeiraEtapaParaProtocoloProcessualTjrj.md
@@ -3,8 +3,8 @@
 ## Propriedades
 Nome | Tipo | Descrição | Notas
 ------------ | ------------- | ------------- | -------------
-**autenticacaoId** | **int** | é o id referente ao tribunal cadastrado em "Tribunais ativos" no Intima.ai | [obrigatório] 
 **numeroProcesso** | **string** | é o numero do processo no qual se deseja realizar o protocolo | [obrigatório] 
+**autenticacaoId** | **int** | é o id referente ao tribunal cadastrado em "Tribunais ativos" no Intima.ai | [obrigatório] 
 
 [[Voltar a lista da API]](../../../README.md#Documentação-para-os-Endpoints-da-API)    
 [[Voltar para o README]](../../../README.md#Intima.ai---SDK-PHP)

--- a/docs/models/protocol/ProtocoloProcessual.md
+++ b/docs/models/protocol/ProtocoloProcessual.md
@@ -3,8 +3,8 @@
 ## Propriedades
 Nome | Tipo | Descrição | Notas
 ------------ | ------------- | ------------- | -------------
-**autenticacaoId** | **int** | é o id referente ao tribunal cadastrado em "Tribunais ativos" no Intima.ai | [obrigatório] 
 **numeroProcesso** | **string** | é o numero do processo no qual se deseja realizar o protocolo | [obrigatório] 
+**autenticacaoId** | **int** | é o id referente ao tribunal cadastrado em "Tribunais ativos" no Intima.ai | [obrigatório] 
 **tipoDocumentoMensagemGeral** | **int** | é o tipo do documento geral | [obrigatório] 
 **descricao** | **string** | é a descrição do protocolo de habilitação | [opcional] 
 **mensagemGeral** | **string** | é a mensagem geral do protocolo de habilitação | [opcional] 

--- a/docs/models/qualification_protocol/PrimeiraEtapaParaProtocoloDeHabilitacao.md
+++ b/docs/models/qualification_protocol/PrimeiraEtapaParaProtocoloDeHabilitacao.md
@@ -3,8 +3,8 @@
 ## Propriedades
 Nome | Tipo | Descrição | Notas
 ------------ | ------------- | ------------- | -------------
-**autenticacaoId** | **int** | é o id referente ao tribunal cadastrado em "Tribunais ativos" no Intima.ai | [obrigatório] 
 **numeroProcesso** | **string** | é o numero do processo no qual se deseja realizar o protocolo de habilitação | [obrigatório] 
+**autenticacaoId** | **int** | é o id referente ao tribunal cadastrado em "Tribunais ativos" no Intima.ai | [obrigatório] 
 
 [[Voltar a lista da API]](../../../README.md#Documentação-para-os-Endpoints-da-API)    
 [[Voltar para o README]](../../../README.md#Intima.ai---SDK-PHP)

--- a/docs/resources/acoesResources.md
+++ b/docs/resources/acoesResources.md
@@ -10,7 +10,7 @@ Todas as URIs são relativas a *https://app.intima.ai/api/v2*
 Método | Requisição HTTP | Descrição
 ------------- | ------------- | -------------
 [**consultarPorId**](acoesResources.md#consultarPorId) | **GET** /acoes/{id} | Visualiza uma ação pelo id
-[**consultarResultadosDaAcao**](acoesResources.md#consultarResultadosDaAcao) | **GET** /acoes/{acao_id}/resultados | Retorna um [**Paginator**](../models/api/Paginator.md) com o resultados de uma ação
+[**consultarResultadosDaAcao**](acoesResources.md#consultarResultadosDaAcao) | **GET** /acoes/{acao_id}/resultados | Retorna um [**Paginator**](../models/api/Paginator.md) com os resultados de uma ação
 
 # **consultarPorId**
 

--- a/docs/resources/autenticacoesResources.md
+++ b/docs/resources/autenticacoesResources.md
@@ -58,6 +58,7 @@ Nome | Tipo | Descrição | Notas
 **autenticacao** | [**NovaAutenticacao**](../models/auth/NovaAutenticacao.md)| parametros necessários para a criação de um novo registro | [obrigatório]
 
 ### Exemplos
+#### Cadastro de autenticacao com certifiado A1
 ```php
 <?php
 
@@ -70,8 +71,40 @@ use Intimaai\Models\NovaAutenticacao;
 try 
 {
     $intimaai = new Intimaai('api_token');
+    
+    // Instânciar um novo objeto NovaAutenticacao com os seguintes parametros:
+    // id do tribunal, id do certificado, null, null, numero da OAB, letra da OAB(opcional), UF da OAB 
+    $autenticacao = new NovaAutenticacao(1, 1, null, null, 'numero OAB', 'letra OAB', 'UF OAB');
+    $resultado = $intimaai->autenticacoes->cadastrarNovaAutenticacao($autenticacao);
+    dump($resultado);
+}
+catch (APIRequestException $exception)
+{
+    dump($exception->toJson());
+}
+catch (\Exception $exception)
+{
+    dump($exception->getMessage());
+}
+?>
+```
+#### Cadastro de autenticacao com login e senha
+```php
+<?php
 
-    $autenticacao = new NovaAutenticacao(1, 1);
+require_once(__DIR__ . '/vendor/autoload.php');
+
+use Intimaai\Intimaai;
+use Intimaai\API\APIRequestException;
+use Intimaai\Models\NovaAutenticacao;
+
+try 
+{
+    $intimaai = new Intimaai('api_token');
+    
+    // Instânciar um novo objeto NovaAutenticacao com os seguintes parametros:
+    // id do tribunal, null, login, senha, numero da OAB, letra da OAB(opcional), UF da OAB 
+    $autenticacao = new NovaAutenticacao(1, null, 'login', 'senha', 'numero OAB', 'letra OAB', 'UF OAB');
     $resultado = $intimaai->autenticacoes->cadastrarNovaAutenticacao($autenticacao);
     dump($resultado);
 }
@@ -109,7 +142,7 @@ try
 {
     $intimaai = new Intimaai('api_token');
 
-    $atualizarAutenticacao = new AtualizarAutenticacao('190792', 'A', 'PB');
+    $atualizarAutenticacao = new AtualizarAutenticacao('numero da OAB', 'letra da OAB', 'UF da OAB');
     $resultado = $intimaai->autenticacoes->atualizarAutenticacao(1, $atualizarAutenticacao);
     dump($resultado);
 }

--- a/docs/resources/autenticacoesResources.md
+++ b/docs/resources/autenticacoesResources.md
@@ -126,7 +126,7 @@ catch (\Exception $exception)
 Nome | Tipo | Descrição | Notas
 ------------- | ------------- | ------------- | -------------
 **autenticacaoId** | **int**| é o id referente ao tribunal cadastrado em "Tribunais ativos" no Intima.ai | [obrigatório]
-**atualizarAutenticacao** | [**AtualizarAutenticacao**](../models/auth/AtualizarAutenticacao.md)| parametros necessários para a atualizar uma autenticação | [obrigatório]
+**atualizarAutenticacao** | [**AtualizarAutenticacao**](../models/auth/AtualizarAutenticacao.md)| parametros necessários para atualizar uma autenticação | [obrigatório]
 
 ### Exemplos
 ```php

--- a/docs/resources/certificadosResources.md
+++ b/docs/resources/certificadosResources.md
@@ -73,7 +73,7 @@ try
 {
     $intimaai = new Intimaai('api_token');
 
-    $certificado = new Certificado('/path/to/file.pfx', '12345678');
+    $certificado = new Certificado('/path/to/file.pfx', 'senha');
     $resultado = $intimaai->certificados->cadastrarNovoCertificado($certificado);
 
     dump($resultado);

--- a/docs/resources/certificadosResources.md
+++ b/docs/resources/certificadosResources.md
@@ -112,7 +112,7 @@ try
 {
     $intimaai = new Intimaai('api_token');
     
-    $certificado = new Certificado('/path/to/file.pfx', '12345678');
+    $certificado = new Certificado('/path/to/file.pfx', 'senha');
     $resultado = $intimaai->certificados->atualizarCertificado(1, $certificado);
     dump($resultado);
 }

--- a/docs/resources/consultasProcessuaisResources.md
+++ b/docs/resources/consultasProcessuaisResources.md
@@ -67,6 +67,7 @@ Nome | Tipo | Descrição | Notas
 **consultaProcessual** | [**ConsultaProcessual**](../models/process_search/ConsultaProcessual.md) | parametros necessários para a criação de um novo registro | [obrigatório]
 
 ### Exemplos
+#### Cadastrar Nova Consulta Com Número do Processo
 ```php
 <?php
 
@@ -94,7 +95,62 @@ catch (\Exception $exception)
 }
 ?>
 ```
+#### Cadastrar Nova Consulta Com Número do Processo e Nome da Parte
+```php
+<?php
 
+require_once(__DIR__ . '/vendor/autoload.php');
+
+use Intimaai\Intimaai;
+use Intimaai\API\APIRequestException;
+use Intimaai\Models\ConsultaProcessual;
+
+try 
+{
+    $intimaai = new Intimaai('api_token');
+
+    $consulta = new ConsultaProcessual(1, '0000000-00.0000.0.00.0000', 'Nome da Parte');
+    $resultado = $intimaai->consultasProcessuais->cadastrarNovaConsulta($consulta);
+    dump($resultado);
+}
+catch (APIRequestException $exception)
+{
+    dump($exception->toJson());
+}
+catch (\Exception $exception)
+{
+    dump($exception->getMessage());
+}
+?>
+```
+#### Cadastrar Nova Consulta Com Número do Processo, Nome da Parte, Nome do representante e numero da OAB
+```php
+<?php
+
+require_once(__DIR__ . '/vendor/autoload.php');
+
+use Intimaai\Intimaai;
+use Intimaai\API\APIRequestException;
+use Intimaai\Models\ConsultaProcessual;
+
+try 
+{
+    $intimaai = new Intimaai('api_token');
+
+    $consulta = new ConsultaProcessual(1, '0000000-00.0000.0.00.0000', 'Nome da Parte', 'Nome do Representante', 'Numero OAB');
+    $resultado = $intimaai->consultasProcessuais->cadastrarNovaConsulta($consulta);
+    dump($resultado);
+}
+catch (APIRequestException $exception)
+{
+    dump($exception->toJson());
+}
+catch (\Exception $exception)
+{
+    dump($exception->getMessage());
+}
+?>
+```
 # **consultarResultadosDaConsulta**
 
 ### Parametros
@@ -209,6 +265,7 @@ Nome | Tipo | Descrição | Notas
 **preAnaliseDeConsultaProcessual** | [**PreAnaliseDeConsultaProcessual**](../models/process_search/PreAnaliseDeConsultaProcessual.md) | parametros necessários para a criação de um novo registro | [obrigatório]
 
 ### Exemplos
+#### Pré Análise Com Número de Processo
 ```php
 <?php
 
@@ -223,6 +280,62 @@ try
     $intimaai = new Intimaai('api_token');
 
     $consultaAnalise = new PreAnaliseDeConsultaProcessual(1, '0000000-00.0000.0.00.0000');
+    $resultado = $intimaai->consultasProcessuais->cadastrarPreAnaliseDeConsulta($consultaAnalise);
+    dump($resultado);
+}
+catch (APIRequestException $exception)
+{
+    dump($exception->toJson());
+}
+catch (\Exception $exception)
+{
+    dump($exception->getMessage());
+}
+?>
+```
+#### Pré Análise Com Número de Processo e Nome da Parte
+```php
+<?php
+
+require_once(__DIR__ . '/vendor/autoload.php');
+
+use Intimaai\Intimaai;
+use Intimaai\API\APIRequestException;
+use Intimaai\Models\PreAnaliseDeConsultaProcessual;
+
+try 
+{
+    $intimaai = new Intimaai('api_token');
+
+    $consultaAnalise = new PreAnaliseDeConsultaProcessual(1, '0000000-00.0000.0.00.0000', 'Nome da Parte');
+    $resultado = $intimaai->consultasProcessuais->cadastrarPreAnaliseDeConsulta($consultaAnalise);
+    dump($resultado);
+}
+catch (APIRequestException $exception)
+{
+    dump($exception->toJson());
+}
+catch (\Exception $exception)
+{
+    dump($exception->getMessage());
+}
+?>
+```
+#### Pré Análise Com Número de Processo, Nome da Parte e Nome do Representante
+```php
+<?php
+
+require_once(__DIR__ . '/vendor/autoload.php');
+
+use Intimaai\Intimaai;
+use Intimaai\API\APIRequestException;
+use Intimaai\Models\PreAnaliseDeConsultaProcessual;
+
+try 
+{
+    $intimaai = new Intimaai('api_token');
+
+    $consultaAnalise = new PreAnaliseDeConsultaProcessual(1, '0000000-00.0000.0.00.0000', 'Nome da Parte', 'Nome do Representante');
     $resultado = $intimaai->consultasProcessuais->cadastrarPreAnaliseDeConsulta($consultaAnalise);
     dump($resultado);
 }

--- a/docs/resources/escutasProcessuaisResources.md
+++ b/docs/resources/escutasProcessuaisResources.md
@@ -131,7 +131,7 @@ catch (\Exception $exception)
 
 Nome | Tipo | Descrição | Notas
 ------------- | ------------- | ------------- | -------------
-**escutaProcessual** | [**Listener**](../models/listener/Listener.md) | parametros necessários para a criação de um novo registro | [obrigatório]
+**escutaProcessual** | [**EscutaProcessual**](../models/listener/EscutaProcessual.md) | parametros necessários para a criação de um novo registro | [obrigatório]
 
 ### Exemplos
 ```php

--- a/docs/resources/informacoesProcessuaisResources.md
+++ b/docs/resources/informacoesProcessuaisResources.md
@@ -68,7 +68,7 @@ try
 {
     $intimaai = new Intimaai('api_token');
 
-    $processoInfo = new InformacaoProcessual('00000000000000000000', 120);
+    $processoInfo = new InformacaoProcessual('0000000-00.0000.0.00.0000', 120);
     $resultado = $intimaai->informacoesProcessuais->capturarNovaInformacaoProcessual($processoInfo);
     dump($resultado);
 }

--- a/docs/resources/protocolosProcessuaisResources.md
+++ b/docs/resources/protocolosProcessuaisResources.md
@@ -95,9 +95,9 @@ try
 {
     $intimaai = new Intimaai('api_token');
     
-//    $peticao = new Peticao('/path/to/doc.pdf', 0, 'doc');
+    $peticao = new Peticao('/path/to/doc.pdf', 0, 'doc');
     $doc = new Documento('/path/to/anexo.pdf', 0, 'anexo', 1);
-    $protocolo = new ProtocoloProcessual('0000000-00.0000.0.00.0000', 1, 0, null, null, null, [$doc]);
+    $protocolo = new ProtocoloProcessual('0000000-00.0000.0.00.0000', 1, 0, 'descricao', 'mensagem geral' $peticao, [$doc]);
 
     $resultado = $intimaai->protocolosProcessuais->cadastrarNovoProtocolo($protocolo);
     dump($resultado);

--- a/docs/resources/protocolosProcessuaisResources.md
+++ b/docs/resources/protocolosProcessuaisResources.md
@@ -97,7 +97,7 @@ try
     
     $peticao = new Peticao('/path/to/doc.pdf', 0, 'doc');
     $doc = new Documento('/path/to/anexo.pdf', 0, 'anexo', 1);
-    $protocolo = new ProtocoloProcessual('0000000-00.0000.0.00.0000', 1, 0, 'descricao', 'mensagem geral' $peticao, [$doc]);
+    $protocolo = new ProtocoloProcessual('0000000-00.0000.0.00.0000', 1, 0, 'descricao', 'mensagem geral', $peticao, [$doc]);
 
     $resultado = $intimaai->protocolosProcessuais->cadastrarNovoProtocolo($protocolo);
     dump($resultado);

--- a/docs/resources/user/notificacoesResources.md
+++ b/docs/resources/user/notificacoesResources.md
@@ -155,5 +155,5 @@ catch (\Exception $exception)
 ```
 
 [[Voltar ao topo]](#)        
-[[Voltar a lista da API]](../../README.md#Documentação-para-os-Endpoints-da-API)    
-[[Voltar para o README]](../../README.md#Intima.ai---SDK-PHP)
+[[Voltar a lista da API]](../../../README.md#Documentação-para-os-Endpoints-da-API)    
+[[Voltar para o README]](../../../README.md#Intima.ai---SDK-PHP)

--- a/docs/resources/user/usuariosResources.md
+++ b/docs/resources/user/usuariosResources.md
@@ -43,5 +43,5 @@ catch (\Exception $exception)
 ```
 
 [[Voltar ao topo]](#)        
-[[Voltar a lista da API]](../../README.md#Documentação-para-os-Endpoints-da-API)    
+[[Voltar a lista da API]](../../../README.md#Documentação-para-os-Endpoints-da-API)    
 [[Voltar para o README]](../../README.md#Intima.ai---SDK-PHP)

--- a/docs/resources/user/webhooksResources.md
+++ b/docs/resources/user/webhooksResources.md
@@ -159,5 +159,5 @@ catch (\Exception $exception)
 ```
 
 [[Voltar ao topo]](#)        
-[[Voltar a lista da API]](../../README.md#Documentação-para-os-Endpoints-da-API)    
-[[Voltar para o README]](../../README.md#Intima.ai---SDK-PHP)
+[[Voltar a lista da API]](../../../README.md#Documentação-para-os-Endpoints-da-API)    
+[[Voltar para o README]](../../../README.md#Intima.ai---SDK-PHP)

--- a/lib/Resources/ProcessCourse/ProcessCourse.php
+++ b/lib/Resources/ProcessCourse/ProcessCourse.php
@@ -52,7 +52,7 @@ class ProcessCourse extends Resource
     public function cadastrarNovoAndamento(AndamentoProcessual $andamentoProcessual)
     {
         $options = [
-            'path' => $this->action->getResourceEndpoint(),
+            'path' => $this->getResourceEndpoint(),
             'method' => API::POST,
             'body' => [
                 'numero_processo' => $andamentoProcessual->getNumeroProcesso(),

--- a/lib/Resources/ProcessListener/ProcessListener.php
+++ b/lib/Resources/ProcessListener/ProcessListener.php
@@ -53,7 +53,7 @@ class ProcessListener extends Resource
     public function cadastrarNovaEscuta(EscutaProcessual $escutaProcessual)
     {
         $options = [
-            'path' => $this->action->getResourceEndpoint(),
+            'path' => $this->getResourceEndpoint(),
             'method' => API::POST,
             'body' => [
                 'numero_processo' => $escutaProcessual->getNumeroProcesso(),

--- a/lib/Resources/ProcessSearch/ProcessSearch.php
+++ b/lib/Resources/ProcessSearch/ProcessSearch.php
@@ -123,7 +123,7 @@ class ProcessSearch extends Resource
      */
     public function cadastrarPreAnaliseDeConsulta(PreAnaliseDeConsultaProcessual $preAnaliseDeConsultaProcessual)
     {
-        if (empty($preAnaliseDeConsultaProcessual->getProcessNumber()) &&
+        if (empty($preAnaliseDeConsultaProcessual->getNumeroProcesso()) &&
             empty($preAnaliseDeConsultaProcessual->getNomeParte()) &&
             empty($preAnaliseDeConsultaProcessual->getNomeRepresentante())) {
             throw new Exception('Você precisa fornecer ao menos um parametro para a busca.');

--- a/lib/Resources/ProcessSearch/ProcessSearch.php
+++ b/lib/Resources/ProcessSearch/ProcessSearch.php
@@ -55,7 +55,7 @@ class ProcessSearch extends Resource
      */
     public function cadastrarNovaConsulta(ConsultaProcessual $consultaProcessual)
     {
-        if (empty($consultaProcessual->getProcessNumber()) &&
+        if (empty($consultaProcessual->getNumeroProcesso()) &&
             empty($consultaProcessual->getNomeParte()) &&
             empty($consultaProcessual->getNomeRepresentante())) {
             throw new Exception('Você precisa fornecer ao menos um parametro para a busca.');

--- a/lib/Resources/ProcessSearch/ProcessSearch.php
+++ b/lib/Resources/ProcessSearch/ProcessSearch.php
@@ -69,9 +69,11 @@ class ProcessSearch extends Resource
                 'autenticacao_id' => $consultaProcessual->getAutenticacaoId(),
                 'nome_parte' => $consultaProcessual->getNomeParte(),
                 'nome_representante' => $consultaProcessual->getNomeRepresentante(),
-                'oab_numero' => $consultaProcessual->getOabNumero(),
-                'oab_letra' => $consultaProcessual->getOabLetra(),
-                'oab_uf' => $consultaProcessual->getOabUf(),
+                'oab' => [
+                    'numero' => $consultaProcessual->getOabNumero(),
+                    'letra' => $consultaProcessual->getOabLetra(),
+                    'uf' => $consultaProcessual->getOabUf()
+                ],
                 'token' => $consultaProcessual->getToken()
             ]
         ];

--- a/lib/Resources/ProcessSearch/ProcessSearch.php
+++ b/lib/Resources/ProcessSearch/ProcessSearch.php
@@ -139,9 +139,11 @@ class ProcessSearch extends Resource
                 'autenticacao_id' => $preAnaliseDeConsultaProcessual->getAutenticacaoId(),
                 'nome_parte' => $preAnaliseDeConsultaProcessual->getNomeParte(),
                 'nome_representante' => $preAnaliseDeConsultaProcessual->getNomeRepresentante(),
-                'oab_numero' => $preAnaliseDeConsultaProcessual->getOabNumero(),
-                'oab_letra' => $preAnaliseDeConsultaProcessual->getOabLetra(),
-                'oab_uf' => $preAnaliseDeConsultaProcessual->getOabUf()
+                'oab' => [
+                    'numero' => $preAnaliseDeConsultaProcessual->getOabNumero(),
+                    'letra' => $preAnaliseDeConsultaProcessual->getOabLetra(),
+                    'uf' => $preAnaliseDeConsultaProcessual->getOabUf()
+                ]
             ]
         ];
         return $this->getAPI()->request($options);


### PR DESCRIPTION
Havia um erro ao executar o método cadastrarNovaEscuta: Era lançado uma exceção informando que o método post não era suportável para a rota. Então alterei a forma de criação da rota do método cadastrarNovaEscuta. Anteriormente o método gerava o path como: "acoes", mas com a alteração a rota gerada será escutas-processuais.

